### PR TITLE
Add thread binding configuration for mpirun in docker machines

### DIFF
--- a/cime_files/config_machines.xml
+++ b/cime_files/config_machines.xml
@@ -31,10 +31,14 @@
 	      <executable>mpirun</executable>
 	      <arguments>
 	            <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	            <arg name="bind_to"> --bind-to core</arg>
+	            <arg name="map_by"> --map-by numa</arg>
 	      </arguments>
       </mpirun>
       <module_system type="none"/>
       <environment_variables>
+        <env name="OMPI_MCA_hwloc_base_binding_policy">core</env>
+        <env name="OMPI_MCA_rmaps_base_mapping_policy">numa</env>
         <env name="HDF5_HOME">/usr</env>
         <env name="NETCDF_PATH">/usr</env>
         <env name="NETCDF_C_PATH">/usr</env>
@@ -72,10 +76,14 @@
 	      <executable>mpirun</executable>
 	      <arguments>
 	            <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	            <arg name="bind_to"> --bind-to core</arg>
+	            <arg name="map_by"> --map-by numa</arg>
 	      </arguments>
       </mpirun>
       <module_system type="none"/>
       <environment_variables>
+        <env name="OMPI_MCA_hwloc_base_binding_policy">core</env>
+        <env name="OMPI_MCA_rmaps_base_mapping_policy">numa</env>
         <env name="HDF5_HOME">/home/$USER/install/tpls</env>
         <env name="NETCDF_PATH">/home/$USER/install/tpls</env>
         <env name="NETCDF_C_PATH">/home/$USER/install/tpls</env>


### PR DESCRIPTION
## Summary

Configures OpenMPI thread binding for both `docker` and `docker-ats` machines to improve performance and consistency in developer tests.

## Changes

This PR adds thread binding configuration to the CIME machine configuration file:

1. **MPI runtime arguments**: Added `--bind-to core` and `--map-by numa` flags to mpirun
2. **Environment variables**: Added OpenMPI MCA parameters for hardware locality binding:
   - `OMPI_MCA_hwloc_base_binding_policy=core`
   - `OMPI_MCA_rmaps_base_mapping_policy=numa`

## Motivation

These settings ensure MPI processes are properly bound to CPU cores and mapped across NUMA domains, which is particularly important when using `ch-run` with Charliecloud containers for developer testing. This matches the thread binding approach used in:

```bash
ch-run -W \
  --set-env=OMPI_MCA_hwloc_base_binding_policy=core \
  --set-env=OMPI_MCA_rmaps_base_mapping_policy=numa \
  ... image -- \
  mpirun -np <N> --bind-to core --map-by numa ./elm
```

## Test plan

- [ ] Run developer tests with the updated configuration
- [ ] Verify mpirun uses the correct binding parameters
- [ ] Confirm performance characteristics are as expected