### PR TITLE
Add MOAB_DIR configuration to CIME files

### DIFF
--- a/cime_files/config_machines.xml
+++ b/cime_files/config_machines.xml
@@ -43,6 +43,7 @@
         <env name="NETCDF_PATH">/usr</env>
         <env name="NETCDF_C_PATH">/usr</env>
         <env name="NETCDF_FORTRAN_PATH">/usr</env>
+        <env name="MOAB_DIR">/usr</env>
       </environment_variables>
    </machine>
    <machine MACH="docker-ats">

--- a/cime_files/gnu_docker.cmake
+++ b/cime_files/gnu_docker.cmake
@@ -13,3 +13,4 @@ string(APPEND SLIBS " -L$ENV{HDF5_HOME}/lib -lhdf5_fortran -lhdf5 -lhdf5_hl -lhd
 string(APPEND SLIBS " -L$ENV{NETCDF_PATH}/lib/ -lnetcdff -lnetcdf -lcurl -lblas -llapack")
 set(HDF5_PATH "$ENV{HDF5_HOME}")
 set(NETCDF_PATH "$ENV{NETCDF_PATH}")
+set(MOAB_DIR "$ENV{MOAB_DIR}")


### PR DESCRIPTION
## Summary
- Set `MOAB_DIR=/usr` in `config_machines.xml` for the docker machine
- Set `MOAB_DIR` in `gnu_docker.cmake` to pass the variable to CMake

## Context
After merging PR #20 which added MOAB installation to the e3sm-dev container, E3SM builds were failing with CMake errors:
```
CMake Error: By not providing "FindMOAB.cmake" in CMAKE_MODULE_PATH this project has
asked CMake to find a package configuration file provided by "MOAB", but CMake did not find one.
```

## Solution
This PR adds the `MOAB_DIR` environment variable pointing to `/usr` (where MOAB is installed in the container) so that CMake's `find_package(MOAB)` can locate the MOAB package configuration files.