### PR TITLE
Drop --enable-debug from MOAB build to shrink image

### DIFF
--- a/e3sm-dev/Dockerfile
+++ b/e3sm-dev/Dockerfile
@@ -110,7 +110,7 @@ RUN cd /tmp \
                     FC=mpif90 \
                     F77=mpif77 \
                     --prefix=/usr \
-                    --enable-debug --enable-optimize \
+                    --enable-optimize \
                     --with-mpi=/usr \
                     --with-hdf5=/usr \
                     --with-netcdf=/usr \


### PR DESCRIPTION
## Summary
- Removes `--enable-debug` from the MOAB configure step in `e3sm-dev/Dockerfile`, keeping `--enable-optimize`.
- The MOAB layer built with debug symbols was ~2.24 GB — the dominant contributor to the e3sm-dev image size. Stripping debug symbols should cut that layer to a few hundred MB.
