### PR TITLE
Enable PnetCDF support in SCORPIO via CIME configuration

### DIFF
--- a/cime_files/gnu_docker-ats.cmake
+++ b/cime_files/gnu_docker-ats.cmake
@@ -13,6 +13,8 @@ string(APPEND SLIBS " -L$ENV{HDF5_HOME}/lib -lhdf5_fortran -lhdf5 -lhdf5_hl -lhd
 string(APPEND SLIBS " -L$ENV{NETCDF_PATH}/lib/ -lnetcdff -lnetcdf -lpnetcdf -lcurl -lblas -llapack")
 set(HDF5_PATH "$ENV{HDF5_HOME}")
 set(NETCDF_PATH "$ENV{NETCDF_PATH}")
+set(PNETCDF_PATH "$ENV{NETCDF_PATH}")
+set(WITH_PNETCDF TRUE)
 set(AMANZI_TPLS_DIR "$ENV{AMANZI_TPLS_DIR}")
 set(ATS_DIR "$ENV{ATS_DIR}")
 if (COMP_CLASS STREQUAL lnd)

--- a/cime_files/gnu_docker.cmake
+++ b/cime_files/gnu_docker.cmake
@@ -13,4 +13,6 @@ string(APPEND SLIBS " -L$ENV{HDF5_HOME}/lib -lhdf5_fortran -lhdf5 -lhdf5_hl -lhd
 string(APPEND SLIBS " -L$ENV{NETCDF_PATH}/lib/ -lnetcdff -lnetcdf -lpnetcdf -lcurl -lblas -llapack")
 set(HDF5_PATH "$ENV{HDF5_HOME}")
 set(NETCDF_PATH "$ENV{NETCDF_PATH}")
+set(PNETCDF_PATH "$ENV{NETCDF_PATH}")
+set(WITH_PNETCDF TRUE)
 set(MOAB_DIR "$ENV{MOAB_DIR}")


### PR DESCRIPTION
## Summary
- Add `PNETCDF_PATH` and `WITH_PNETCDF` CMake variables to CIME configuration files
- Enables PnetCDF I/O type support in SCORPIO during E3SM builds
- Fixes "Invalid iotype (PIO_IOTYPE_PNETCDF:1)" runtime error in rfiorella/e3sm-dev-amd64-v4-znver4 container

## Problem
SCORPIO was rejecting `PIO_IOTYPE_PNETCDF` (iotype 1) at runtime with the error:
```
PIO: FATAL ERROR: Invalid iotype (PIO_IOTYPE_PNETCDF:1) specified. 
Available iotypes are : PIO_IOTYPE_NETCDF (2), PIO_IOTYPE_NETCDF4C (3), 
PIO_IOTYPE_NETCDF4P (4), PIO_IOTYPE_NETCDF4P_NCZARR (5).
```

While the PnetCDF library was installed in the base image and linked via `-lpnetcdf`, SCORPIO wasn't configured at build-time to include PnetCDF I/O support.

## Solution
Added CMake configuration variables to both `gnu_docker.cmake` and `gnu_docker-ats.cmake`:
- `PNETCDF_PATH` - points to PnetCDF installation location
- `WITH_PNETCDF TRUE` - enables PnetCDF support in SCORPIO build