### PR TITLE
Build PnetCDF with shared libraries

### DIFF
--- a/base-ubuntu/Dockerfile
+++ b/base-ubuntu/Dockerfile
@@ -127,7 +127,7 @@ RUN cd / \
    && git clone --depth 1 --branch checkpoint.1.13.0 https://github.com/Parallel-NetCDF/PnetCDF.git \
    && cd PnetCDF \
    && autoreconf -i \
-   && CC=mpicc FC=mpifort CPPFLAGS="-fPIC -O2" ./configure --disable-in-place-swap --prefix=/usr/ \
+   && CC=mpicc FC=mpifort CPPFLAGS="-fPIC -O2" ./configure --enable-shared --disable-in-place-swap --prefix=/usr/ \
    && make \
    && make install \
    && cd / \

--- a/base-ubuntu/Dockerfile.tuned
+++ b/base-ubuntu/Dockerfile.tuned
@@ -143,7 +143,7 @@ RUN . /etc/profile.d/arch_flags.sh && \
    && git clone --depth 1 --branch checkpoint.1.13.0 https://github.com/Parallel-NetCDF/PnetCDF.git \
    && cd PnetCDF \
    && autoreconf -i \
-   && CC=mpicc FC=mpifort CPPFLAGS="-fPIC -O2 ${ARCH_FLAGS}" ./configure --disable-in-place-swap --prefix=/usr/ \
+   && CC=mpicc FC=mpifort CPPFLAGS="-fPIC -O2 ${ARCH_FLAGS}" ./configure --enable-shared --disable-in-place-swap --prefix=/usr/ \
    && make \
    && make install \
    && cd / \


### PR DESCRIPTION
## Summary
- Add `--enable-shared` to the PnetCDF configure step in `base-ubuntu/Dockerfile` and `base-ubuntu/Dockerfile.tuned`.
- PnetCDF autotools default builds a static archive only (`libpnetcdf.a`). This flag also produces `libpnetcdf.so`, so the images ship **both** static and shared libraries.

## Why
Follows up the recent PnetCDF/SCORPIO enablement work (#23, #24). SCORPIO links PnetCDF fine statically today, but shared linking lets netCDF-C and downstream executables link dynamically (runtime `LD_LIBRARY_PATH=/usr/lib` is already set), shrinking per-executable size while keeping the static archive available.

`-fPIC` is already in `CPPFLAGS`, so no other change was needed.

## Verification
- Confirmed on `e3sm-dev-amd64-v4-znver4` that pre-change images ship static-only (`libpnetcdf.a`, no `.so`), headers present at `/usr`, `nc-config --has-pnetcdf=yes`.
- Full rebuild verification left to CI — znver4 amd64 binaries are not runnable on the arm64 host.