### PR TITLE
Fix PnetCDF_PATH variable name case

### DIFF
--- a/cime_files/gnu_docker-ats.cmake
+++ b/cime_files/gnu_docker-ats.cmake
@@ -13,7 +13,7 @@ string(APPEND SLIBS " -L$ENV{HDF5_HOME}/lib -lhdf5_fortran -lhdf5 -lhdf5_hl -lhd
 string(APPEND SLIBS " -L$ENV{NETCDF_PATH}/lib/ -lnetcdff -lnetcdf -lpnetcdf -lcurl -lblas -llapack")
 set(HDF5_PATH "$ENV{HDF5_HOME}")
 set(NETCDF_PATH "$ENV{NETCDF_PATH}")
-set(PNETCDF_PATH "$ENV{NETCDF_PATH}")
+set(PnetCDF_PATH "$ENV{NETCDF_PATH}")
 set(WITH_PNETCDF TRUE)
 set(AMANZI_TPLS_DIR "$ENV{AMANZI_TPLS_DIR}")
 set(ATS_DIR "$ENV{ATS_DIR}")

--- a/cime_files/gnu_docker.cmake
+++ b/cime_files/gnu_docker.cmake
@@ -13,6 +13,6 @@ string(APPEND SLIBS " -L$ENV{HDF5_HOME}/lib -lhdf5_fortran -lhdf5 -lhdf5_hl -lhd
 string(APPEND SLIBS " -L$ENV{NETCDF_PATH}/lib/ -lnetcdff -lnetcdf -lpnetcdf -lcurl -lblas -llapack")
 set(HDF5_PATH "$ENV{HDF5_HOME}")
 set(NETCDF_PATH "$ENV{NETCDF_PATH}")
-set(PNETCDF_PATH "$ENV{NETCDF_PATH}")
+set(PnetCDF_PATH "$ENV{NETCDF_PATH}")
 set(WITH_PNETCDF TRUE)
 set(MOAB_DIR "$ENV{MOAB_DIR}")


### PR DESCRIPTION
SCORPIO expects PnetCDF_PATH (mixed case) not PNETCDF_PATH (all caps). The CMakeLists.txt converts the old PNETCDF_DIR to PnetCDF_PATH.