### PR TITLE
Add PNETCDF_PATH environment variable to enable SCORPIO PnetCDF support

### DIFF
--- a/cime_files/config_machines.xml
+++ b/cime_files/config_machines.xml
@@ -43,6 +43,7 @@
         <env name="NETCDF_PATH">/usr</env>
         <env name="NETCDF_C_PATH">/usr</env>
         <env name="NETCDF_FORTRAN_PATH">/usr</env>
+        <env name="PNETCDF_PATH">/usr</env>
         <env name="MOAB_DIR">/usr</env>
       </environment_variables>
    </machine>
@@ -89,6 +90,7 @@
         <env name="NETCDF_PATH">/home/$USER/install/tpls</env>
         <env name="NETCDF_C_PATH">/home/$USER/install/tpls</env>
         <env name="NETCDF_FORTRAN_PATH">/home/$USER/install/tpls</env>
+        <env name="PNETCDF_PATH">/home/$USER/install/tpls</env>
       </environment_variables>
    </machine>
 </config_machines>


### PR DESCRIPTION
The buildlib.spio script checks for PNETCDF_PATH in os.environ, not from CMake macros. Without this environment variable set in config_machines.xml, SCORPIO is built with -DWITH_PNETCDF:LOGICAL=FALSE regardless of cmake settings.

This adds PNETCDF_PATH=/usr for docker machine and PNETCDF_PATH=/home/$USER/install/tpls for docker-ats machine.