### PR TITLE
Fix docker machine CCSM_CPRNC path

### DIFF
--- a/cime_files/config_machines.xml
+++ b/cime_files/config_machines.xml
@@ -15,7 +15,8 @@
       <DIN_LOC_ROOT_CLMFORC>/home/$USER/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
       <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
       <BASELINE_ROOT>/home/$USER/baselines</BASELINE_ROOT>
-      <CCSM_CPRNC>/home/$USER/tools/cprnc</CCSM_CPRNC>
+      <!-- cprnc is installed to /usr/bin by e3sm-dev/Dockerfile (CMAKE_INSTALL_PREFIX=/usr) -->
+      <CCSM_CPRNC>/usr/bin/cprnc</CCSM_CPRNC>
       <GMAKE>make</GMAKE>
       <GMAKE_J>4</GMAKE_J>
       <BATCH_SYSTEM>none</BATCH_SYSTEM>


### PR DESCRIPTION
cprnc is installed to /usr/bin by e3sm-dev/Dockerfile (CMAKE_INSTALL_PREFIX=/usr), but config_machines.xml pointed CCSM_CPRNC at /home/$USER/tools/cprnc. Point CCSM_CPRNC at /usr/bin/cprnc so it matches the installed binary, fixing COMPARE_base_rest failures for e3sm_land_developer tests on the docker machine.