### PR TITLE
Add Microsoft Aurora container

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -82,3 +82,88 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER}}/model-containers:e3sm-serial-dev-latest
           platforms: linux/amd64, linux/arm64
           build-args: BASE_TAG=base-serial-latest
+# aurora is self-contained (clones its own source) and does not use base-serial,
+# so these build in parallel with the jobs above.
+#
+# The cpu and cuda images are separate images, not one multi-arch manifest --
+# they carry different accelerators, not different arches of the same thing.
+#
+# The cpu image is multi-arch (amd64 + arm64). Built on native runners per arch
+# and joined with a manifest, following build-base above, rather than emulated
+# under QEMU -- a torch install plus an emulated python import check is painfully
+# slow on a QEMU aarch64 leg.
+#
+# The arm64 cpu image is CPU-only by necessity, not oversight: Metal/MPS is not
+# reachable from a Linux guest on Apple Silicon (neither Docker Desktop nor
+# apple/container passes the GPU through), so there is no arm64 GPU image to
+# build. For M-series GPU, run aurora natively on macOS with device="mps".
+  build-aurora-cpu:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v7
+      - name: Get runner architecture
+        run: |
+          if [[ ${{matrix.os}} == "ubuntu-24.04-arm" ]]; then
+            echo "ARCH=arm64" >> $GITHUB_ENV
+          else
+            echo "ARCH=amd64" >> $GITHUB_ENV
+          fi
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: build and push aurora cpu image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./ai-models/aurora
+          file: ./ai-models/aurora/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER}}/model-containers:aurora-cpu-${{ env.ARCH }}-latest
+  aurora-cpu-manifest:
+    needs: build-aurora-cpu
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - name: Pull images
+        run: |
+          docker pull ${{ env.IMAGE_OWNER}}/model-containers:aurora-cpu-arm64-latest
+          docker pull ${{ env.IMAGE_OWNER}}/model-containers:aurora-cpu-amd64-latest
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Edit manifest
+        run: |
+          docker manifest create ${{ env.IMAGE_OWNER}}/model-containers:aurora-cpu-latest \
+            --amend ${{ env.IMAGE_OWNER}}/model-containers:aurora-cpu-arm64-latest \
+            --amend ${{ env.IMAGE_OWNER}}/model-containers:aurora-cpu-amd64-latest
+          docker manifest push ${{ env.IMAGE_OWNER}}/model-containers:aurora-cpu-latest
+  build-aurora-cuda:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v7
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: build and push aurora cuda image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./ai-models/aurora
+          file: ./ai-models/aurora/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER}}/model-containers:aurora-cuda-latest
+          platforms: linux/amd64
+          build-args: |
+            BASE_IMAGE=nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
+            TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: EAMXX-wiso EAMv2-wiso EAMv3-wiso NGEE-master NGEE-IM3-debug NGEE-IM2-debug NGEE-IM1-debug ELM-ATS ELM-ATS-debug interface
+.PHONY: EAMXX-wiso EAMv2-wiso EAMv3-wiso NGEE-master NGEE-IM3-debug NGEE-IM2-debug NGEE-IM1-debug ELM-ATS ELM-ATS-debug interface aurora-cpu aurora-cuda
 
 EAMXX-wiso:
 	docker run --rm -it -v /code/build-models/eamxx:/home/e3smuser/scripts -v /data/scream/baselines:/home/e3smuser/baselines -v /code/E3SM/EAMxx-wiso:/home/e3smuser/E3SM -v /Volumes/neon_e3sm/inputdata:/home/e3smuser/inputdata -v /data/scream/output:/home/e3smuser/output rfiorella/model-containers:e3sm-openmpi-dev-latest
@@ -29,3 +29,9 @@ ELM-ATS-debug:
 
 interface:
 	docker run --rm -it -v /code/E3SM/interface-lakes:/home/e3smuser/E3SM -v /Volumes/neon_e3sm/inputdata:/home/e3smuser/inputdata -v /data/interface:/home/e3smuser/output -v /code/E3SM/OLMT:/home/e3smuser/OLMT rfiorella/model-containers:e3sm-openmpi-dev-latest
+
+aurora-cpu:
+	docker run --rm -it -v /code/ai-models/aurora:/home/aurora/work -v /data/aurora/data:/home/aurora/data -v /data/aurora/output:/home/aurora/output -v /data/aurora/hf-cache:/opt/hf-cache rfiorella/model-containers:aurora-cpu-latest
+
+aurora-cuda:
+	docker run --rm -it --gpus all -v /code/ai-models/aurora:/home/aurora/work -v /data/aurora/data:/home/aurora/data -v /data/aurora/output:/home/aurora/output -v /data/aurora/hf-cache:/opt/hf-cache rfiorella/model-containers:aurora-cuda-latest

--- a/ai-models/aurora/Dockerfile
+++ b/ai-models/aurora/Dockerfile
@@ -1,0 +1,146 @@
+# ----------------------------------------------------------------------
+# Microsoft Aurora (https://github.com/microsoft/aurora)
+#
+# Two stages:
+#   builder  - clones the source and builds a wheel (hatch-vcs needs the
+#              full git history/tags to derive the version)
+#   runtime  - installs torch from the selected wheel index, then the
+#              locally built aurora wheel
+#
+# Build (CPU, matches the multi-arch pattern used elsewhere in this repo):
+#   docker build -t rfiorella/model-containers:aurora-latest ai-models/aurora
+#
+# Build (CUDA 12.4):
+#   docker build \
+#     --build-arg BASE_IMAGE=nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 \
+#     --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124 \
+#     -t rfiorella/model-containers:aurora-cuda-latest ai-models/aurora
+#
+# Note: the CUDA base ships its own python; PYTHON_VERSION is ignored there.
+# ----------------------------------------------------------------------
+
+ARG PYTHON_VERSION=3.11
+ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bookworm
+
+# ---------------------------------------------------------------- builder
+FROM ${BASE_IMAGE} AS builder
+
+ARG AURORA_REPO=https://github.com/microsoft/aurora.git
+# A tag (v2.0.1), branch (main), or commit SHA.
+ARG AURORA_VERSION=v2.0.1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_ROOT_USER_ACTION=ignore
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        python3 \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --break-system-packages --upgrade pip build hatchling hatch-vcs \
+    || python3 -m pip install --upgrade pip build hatchling hatch-vcs
+
+WORKDIR /src
+
+# Full clone on purpose: hatch-vcs reads git tags to stamp aurora/_version.py,
+# and a shallow clone loses them for anything but an exact tag checkout.
+RUN git clone "${AURORA_REPO}" aurora \
+    && cd aurora \
+    && git checkout "${AURORA_VERSION}" \
+    && git log -1 --pretty="commit %H (%d)"
+
+RUN cd /src/aurora && python3 -m build --wheel --outdir /wheels \
+    && ls -l /wheels
+
+# ---------------------------------------------------------------- runtime
+FROM ${BASE_IMAGE} AS runtime
+
+LABEL org.opencontainers.image.title="microsoft-aurora" \
+      org.opencontainers.image.source="https://github.com/microsoft/aurora" \
+      org.opencontainers.image.licenses="MIT"
+
+# https://download.pytorch.org/whl/cpu | .../cu124 | .../cu121
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
+# Leave empty to take whatever torch version aurora resolves to.
+ARG TORCH_VERSION=
+# Set to "true" to bake the ~5 GB IFS-HRES-T0 checkpoint into the image.
+ARG PREFETCH_CHECKPOINT=false
+ARG USERNAME=aurora
+ARG UID=1000
+ARG GID=1000
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    HF_HOME=/opt/hf-cache \
+    OMP_NUM_THREADS=1
+
+RUN apt-get update -y \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        libgomp1 \
+        python3 \
+        python3-pip \
+        python3-venv \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# Virtualenv keeps us off the distro python and out of PEP 668's way.
+RUN python3 -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:$PATH
+
+RUN pip install --upgrade pip setuptools wheel
+
+# torch first, from the chosen index, so the aurora install does not pull the
+# default (CUDA) wheel from PyPI and blow up the image.
+#
+# torchvision has to come from the same index in the same resolve: aurora -> timm
+# imports torchvision unconditionally, and torchvision ships compiled ops linked
+# against one exact torch build. Letting pip satisfy timm's torchvision dep from
+# PyPI pairs a PyPI torchvision with the +cpu torch installed here and the import
+# dies with "RuntimeError: operator torchvision::nms does not exist".
+RUN if [ -n "${TORCH_VERSION}" ]; then \
+        pip install --index-url "${TORCH_INDEX_URL}" "torch==${TORCH_VERSION}" torchvision; \
+    else \
+        pip install --index-url "${TORCH_INDEX_URL}" torch torchvision; \
+    fi
+
+COPY --from=builder /wheels /tmp/wheels
+RUN pip install /tmp/wheels/microsoft_aurora-*.whl \
+    && rm -rf /tmp/wheels
+
+# Fail the build here rather than at runtime if the install is broken.
+# The aurora package exposes no __version__ attribute (hatch-vcs writes
+# aurora/_version.py but __init__.py never re-exports it), so read the version
+# off the installed distribution instead.
+RUN python -c "import aurora, torch, torchvision; \
+from importlib.metadata import version; \
+print('aurora', version('microsoft-aurora')); \
+print('torch', torch.__version__, 'torchvision', torchvision.__version__, 'cuda', torch.cuda.is_available()); \
+from aurora import Aurora, AuroraSmallPretrained, Batch, Metadata, rollout"
+
+RUN mkdir -p ${HF_HOME} \
+    && if [ "${PREFETCH_CHECKPOINT}" = "true" ]; then \
+         python -c "from aurora import Aurora; Aurora().load_checkpoint()"; \
+       fi
+
+RUN groupadd -g ${GID} ${USERNAME} \
+    && useradd -m -u ${UID} -g ${GID} -s /bin/bash ${USERNAME} \
+    && mkdir -p /home/${USERNAME}/work /home/${USERNAME}/data /home/${USERNAME}/output \
+    && chown -R ${UID}:${GID} /home/${USERNAME} ${HF_HOME}
+
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}/work
+
+CMD ["python"]

--- a/ai-models/aurora/Dockerfile
+++ b/ai-models/aurora/Dockerfile
@@ -7,8 +7,14 @@
 #   runtime  - installs torch from the selected wheel index, then the
 #              locally built aurora wheel
 #
-# Build (CPU, matches the multi-arch pattern used elsewhere in this repo):
-#   docker build -t rfiorella/model-containers:aurora-latest ai-models/aurora
+# This builds two separate images, selected by build args. CI builds the cpu
+# image for amd64 + arm64 and joins them with a manifest; the cuda image is
+# amd64 only. There is no arm64 GPU image because Metal/MPS is not reachable
+# from a Linux guest on Apple Silicon -- for M-series GPU, install aurora
+# natively on macOS and use device="mps".
+#
+# Build (CPU):
+#   docker build -t rfiorella/model-containers:aurora-cpu-latest ai-models/aurora
 #
 # Build (CUDA 12.4):
 #   docker build \
@@ -42,8 +48,12 @@ RUN apt-get update -y \
         python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install --break-system-packages --upgrade pip build hatchling hatch-vcs \
-    || python3 -m pip install --upgrade pip build hatchling hatch-vcs
+# Plain install first: it is what works on both supported bases (the python image
+# ships its own non-externally-managed python, and the CUDA base is ubuntu 22.04,
+# which predates PEP 668 enforcement -- and predates the flag itself, pip 22.0.2).
+# The flag is the fallback, for a base that does enforce PEP 668.
+RUN python3 -m pip install --upgrade pip build hatchling hatch-vcs \
+    || python3 -m pip install --break-system-packages --upgrade pip build hatchling hatch-vcs
 
 WORKDIR /src
 


### PR DESCRIPTION
Adds a container for [Microsoft Aurora](https://github.com/microsoft/aurora) (`microsoft-aurora` v2.0.1), the Earth-system foundation model, plus CI jobs and Makefile run targets.

## Images

Two separate images rather than one multi-arch manifest — they carry different accelerators, not different arches of the same thing. Both build from the same Dockerfile, selected via `BASE_IMAGE` / `TORCH_INDEX_URL` build args.

| tag | arch | torch | Makefile target |
| --- | --- | --- | --- |
| `aurora-cpu-latest` | amd64 + arm64 | cpu wheels | `make aurora-cpu` |
| `aurora-cuda-latest` | amd64 | cu124 wheels | `make aurora-cuda` (adds `--gpus all`) |

## Dockerfile notes

- **Full git clone in the builder stage.** The project uses `hatch-vcs` and stamps its version from git tags; a shallow clone loses them for anything but an exact tag checkout.
- **torch and torchvision installed before the aurora wheel, from the same index.** Installing torch first keeps pip from pulling the default CUDA torch off PyPI into the CPU image. torchvision has to join that same resolve because `aurora -> timm` imports it unconditionally, and torchvision's compiled ops are linked against one exact torch build — a PyPI torchvision paired with a `+cpu` torch dies at import with \`RuntimeError: operator torchvision::nms does not exist\`.
- **Build-time import smoke test**, so a broken install fails the build rather than the first run.
- **Non-root \`aurora\` user**, workdir \`/home/aurora/work\`.
- **Checkpoints are not baked in** (\`PREFETCH_CHECKPOINT\` defaults to false). The Makefile targets mount a host dir at \`HF_HOME\` so the multi-GB weights persist across runs instead of re-downloading.

## CI

The cpu image builds on native per-arch runners and is joined with `docker manifest create`, following the existing `build-base` / `fix-manifest` pattern, rather than emulating aarch64 under QEMU — a torch install plus an emulated python import check is slow enough there to risk the runner time limit. Neither aurora job depends on `base-serial`, so both run in parallel with the existing jobs.

## Why there is no arm64 GPU image

Not an oversight — it isn't possible. Metal/MPS is unreachable from a Linux guest on Apple Silicon: both Docker Desktop and `apple/container` run each container in a Linux VM with no GPU passthrough ([open request](https://github.com/apple/container/discussions/62)), so PyTorch's MPS backend silently falls back to CPU. The arm64 cpu image is still worth having — it runs natively on M-series rather than under emulation — but M-series GPU use requires a native macOS install, not a container.

## Verification status

- The Dockerfile build was verified locally on arm64; that exercised the arch-independent logic (wheel build, hatch-vcs version stamp, torch/torchvision pairing, imports) and surfaced the torchvision fix above.
- The CUDA variant has **not** been built or run — no NVIDIA GPU available locally. First CI run is its real test.