### PR TITLE
Add psutil, pyyaml, packaging to e3sm-dev image

### DIFF
--- a/e3sm-dev/Dockerfile
+++ b/e3sm-dev/Dockerfile
@@ -17,14 +17,16 @@ RUN groupadd -r dockerusers \
 
 USER ${USER}
 
-## Install python libraries for OLMT
+## Install python libraries for OLMT and the EAMxx standalone test harness
+## (test-all-eamxx imports psutil, pyyaml, and packaging).
 RUN pip3 install --break-system-packages --upgrade pip \
     && pip3 install --break-system-packages --upgrade setuptools \
     && pip3 install --break-system-packages --upgrade wheel \
     && pip3 install --break-system-packages numpy Cython \
     && pip3 install --break-system-packages netcdf4 scipy mpi4py \
     && pip3 install --break-system-packages cftime configparser \
-    && pip3 install --break-system-packages h5py
+    && pip3 install --break-system-packages h5py \
+    && pip3 install --break-system-packages psutil pyyaml packaging
 
 USER root
 


### PR DESCRIPTION
Add the three Python packages that the EAMxx standalone test driver requires but the image lacked.

## Summary

- `test-all-eamxx` (`components/eamxx/scripts/`) imports `psutil` (via `ensure_psutil`), `pyyaml`, and `packaging`.
- None of these were installed in `rfiorella/model-containers:e3sm-dev-latest`, so the driver aborts before it can configure or build EAMxx.
- Added them to the existing pip block in `e3sm-dev/Dockerfile`.

## Testing

Verified that with these packages installed, `test-all-eamxx -m linux-generic -t dbg --config-only` configures successfully and `ctest -R water_isotopes_fractionation` builds and passes inside the container.